### PR TITLE
Increased max USB transfer size and modified XSCOPE  for the control application

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Device control library change log
 =================================
 
+3.2.0
+-----
+
+  * Updated XSCOPE and USB protocols for host applications
+
 3.1.1
 -----
 

--- a/examples/xscope/host/src/pause.h
+++ b/examples/xscope/host/src/pause.h
@@ -24,7 +24,7 @@ static void pause_long()
 
 static void pause_short()
 {
-  usleep(100000);
+  usleep(1000);
 }
 
 static void pause_long()

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -231,10 +231,10 @@ control_ret_t control_init_usb(int vendor_id, int product_id, int interface_num)
   }
 
   libusb_device **devs = NULL;
-  libusb_get_device_list(NULL, &devs);
+  int num_dev = libusb_get_device_list(NULL, &devs);
 
   libusb_device *dev = NULL;
-  for (int i = 0; devs[i] != NULL; i++) {
+  for (int i = 0; i < num_dev; i++) {
     struct libusb_device_descriptor desc;
     libusb_get_device_descriptor(devs[i], &desc);
     if (desc.idVendor == vendor_id && desc.idProduct == product_id) {

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -29,13 +29,13 @@ static libusb_device_handle *devh = NULL;
 
 static const int sync_timeout_ms = 100;
 
-/* USB 2.0 section 5.5.3 */
-#define CONTROL_MAX_PAYLOAD_SIZE 64
+/* Control query transfers require smaller buffers */
+#define VERSION_MAX_PAYLOAD_SIZE 64
 
 control_ret_t control_query_version(control_version_t *version)
 {
   uint16_t windex, wvalue, wlength;
-  uint8_t request_data[CONTROL_MAX_PAYLOAD_SIZE];
+  uint8_t request_data[VERSION_MAX_PAYLOAD_SIZE];
 
   control_usb_fill_header(&windex, &wvalue, &wlength,
     CONTROL_SPECIAL_RESID, CONTROL_GET_VERSION, sizeof(control_version_t));
@@ -70,20 +70,20 @@ control_ret_t control_query_version(control_version_t *version)
  * Ideally we would examine configuration descriptors and check for actual
  * wMaxPacketSize on given control endpoint.
  *
- * For now, just assume the greatest control transfer size, 64. Have host
+ * For now, just assume the greatest control transfer size, USB_TRANSACTION_MAX_BYTES. Have host
  * code only check payload size here. Device will not need any additional
  * checks. Device application code will set wMaxPacketSize in its
  * descriptors and take care of allocating a buffer for receiving control
- * requests of up to 64 bytes.
+ * requests of up to USB_TRANSACTION_MAX_BYTES bytes.
  *
  * Without checking, libusb would set wLength in header to any number and
  * only send 64 bytes of payload, truncating the rest.
  */
 static bool payload_len_exceeds_control_packet_size(size_t payload_len)
 {
-  if (payload_len > CONTROL_MAX_PAYLOAD_SIZE) {
+  if (payload_len > USB_TRANSACTION_MAX_BYTES) {
     printf("control transfer of %zd bytes requested\n", payload_len);
-    printf("maximum control packet size is %d\n", CONTROL_MAX_PAYLOAD_SIZE);
+    printf("maximum control packet size is %d\n", USB_TRANSACTION_MAX_BYTES);
     return true;
   }
   else {

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -72,6 +72,7 @@ void record_callback(unsigned int id, unsigned long long timestamp,
     last_response_struct = (struct control_xscope_response*)last_response;
     last_response_length = length;
     memcpy(last_response, databytes, length);
+    
     record_count++;
   }
 }

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -185,7 +185,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    // do nothing
+    pause_short();
   }
 
   DBG(printf("response: "));
@@ -215,7 +215,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    // do nothing
+    pause_short();
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -72,7 +72,6 @@ void record_callback(unsigned int id, unsigned long long timestamp,
     last_response_struct = (struct control_xscope_response*)last_response;
     last_response_length = length;
     memcpy(last_response, databytes, length);
-
     record_count++;
   }
 }
@@ -126,7 +125,7 @@ control_ret_t control_query_version(control_version_t *version)
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+    // do nothing
   }
 
   DBG(printf("response: "));
@@ -185,7 +184,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+    // do nothing
   }
 
   DBG(printf("response: "));
@@ -215,7 +214,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+    // do nothing
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/util.c
+++ b/lib_device_control/host/util.c
@@ -14,7 +14,7 @@
 
 void pause_short(void)
 {
-  Sleep(1);
+  Sleep(0);
 }
 
 void pause_long(void)
@@ -38,7 +38,7 @@ void pause_long(void)
 
 void pause_short(void)
 {
-  usleep(100000);
+  usleep(0);
 }
 
 void pause_long(void)

--- a/lib_device_control/module_build_info
+++ b/lib_device_control/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 3.1.1
+VERSION = 3.2.0
 
 DEPENDENT_MODULES = lib_xassert(>=3.0.0) lib_logging(>=2.1.0)
 

--- a/lib_device_control/src/control_host_support.h
+++ b/lib_device_control/src/control_host_support.h
@@ -22,7 +22,7 @@ control_xscope_create_upload_buffer(uint32_t buffer[XSCOPE_UPLOAD_MAX_WORDS],
   p->resid = resid;
   p->cmd = cmd;
 
-  assert(payload_len < (1<<8) && "payload length can't be represented as a uint8_t");
+  assert(payload_len <= XSCOPE_DATA_MAX_BYTES && "payload length can't be represented as a uint8_t");
   p->payload_len = (uint8_t)payload_len;
 
   if (!IS_CONTROL_CMD_READ(cmd) && payload != NULL) {

--- a/lib_device_control/src/control_transport.h
+++ b/lib_device_control/src/control_transport.h
@@ -39,6 +39,7 @@ struct control_xscope_response {
 // hard limit of 256 bytes for xSCOPE uploads
 #define XSCOPE_UPLOAD_MAX_BYTES (XSCOPE_UPLOAD_MAX_WORDS * 4)
 #define XSCOPE_UPLOAD_MAX_WORDS 64
+#define XSCOPE_DATA_MAX_BYTES (XSCOPE_UPLOAD_MAX_BYTES - 9)
 
 #define I2C_TRANSACTION_MAX_BYTES 256
 #define I2C_DATA_MAX_BYTES (I2C_TRANSACTION_MAX_BYTES - 3)

--- a/lib_device_control/src/control_transport.h
+++ b/lib_device_control/src/control_transport.h
@@ -39,6 +39,7 @@ struct control_xscope_response {
 // hard limit of 256 bytes for xSCOPE uploads
 #define XSCOPE_UPLOAD_MAX_BYTES (XSCOPE_UPLOAD_MAX_WORDS * 4)
 #define XSCOPE_UPLOAD_MAX_WORDS 64
+// the number of bytes subtracted below has been found during testing
 #define XSCOPE_DATA_MAX_BYTES (XSCOPE_UPLOAD_MAX_BYTES - 9)
 
 #define I2C_TRANSACTION_MAX_BYTES 256

--- a/lib_device_control/src/control_transport.h
+++ b/lib_device_control/src/control_transport.h
@@ -39,8 +39,8 @@ struct control_xscope_response {
 // hard limit of 256 bytes for xSCOPE uploads
 #define XSCOPE_UPLOAD_MAX_BYTES (XSCOPE_UPLOAD_MAX_WORDS * 4)
 #define XSCOPE_UPLOAD_MAX_WORDS 64
-// the number of bytes subtracted below has been found during testing
-#define XSCOPE_DATA_MAX_BYTES (XSCOPE_UPLOAD_MAX_BYTES - 9)
+// subtract the header size from the total upload size
+#define XSCOPE_DATA_MAX_BYTES (XSCOPE_UPLOAD_MAX_BYTES - 4)
 
 #define I2C_TRANSACTION_MAX_BYTES 256
 #define I2C_DATA_MAX_BYTES (I2C_TRANSACTION_MAX_BYTES - 3)

--- a/lib_device_control/src/control_transport.h
+++ b/lib_device_control/src/control_transport.h
@@ -27,6 +27,15 @@ struct control_xscope_response {
 #define CONTROL_GET_VERSION CONTROL_CMD_SET_READ(0)
 #define CONTROL_GET_LAST_COMMAND_STATUS CONTROL_CMD_SET_READ(1)
 
+/* The max USB packet size is 64B (USB 2.0 section 5.5.3), 
+ * but larger data transfers are fragmented into several packets.
+ * During testing with full speed USB it has been reported that control transfers 
+ * larger than 8kB cause glitches in the audio playback, since most of the transfer 
+ * time is taken by the control data, limiting the time left for the audio data.
+*/
+#define USB_TRANSACTION_MAX_BYTES 2048
+#define USB_DATA_MAX_BYTES USB_TRANSACTION_MAX_BYTES
+
 // hard limit of 256 bytes for xSCOPE uploads
 #define XSCOPE_UPLOAD_MAX_BYTES (XSCOPE_UPLOAD_MAX_WORDS * 4)
 #define XSCOPE_UPLOAD_MAX_WORDS 64


### PR DESCRIPTION
- updated USB control transfer size to 2048 bytes
- moved definition of USB_TRANSACTION_MAX_BYTES to header file, as it is done for the other transport protocols
- removed pause in XSCOPE control since it was delaying the tuning tests. Removing the pause didn't cause any instability
- added and used XSCOPE_DATA_MAX_BYTES