### PR TITLE
fix for different OS variants of libusb

### DIFF
--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -32,7 +32,7 @@ static const int sync_timeout_ms = 100;
 /* Control query transfers require smaller buffers */
 #define VERSION_MAX_PAYLOAD_SIZE 64
 
-control_ret_t debug_libusb_error(int err_code)
+void debug_libusb_error(int err_code)
 {
       printf("libusb_control_transfer returned %s\n",
 #if defined _WIN32

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -34,15 +34,14 @@ static const int sync_timeout_ms = 100;
 
 void debug_libusb_error(int err_code)
 {
-      printf("libusb_control_transfer returned %s\n",
 #if defined _WIN32
-                  usb_strerror()
+  printf("libusb_control_transfer returned %s\n", usb_strerror());
 #elif defined __APPLE__
-                  libusb_error_name(err_code)
+  printf("libusb_control_transfer returned %s\n", libusb_error_name(err_code));
 #elif defined __linux
-                  err_code
+  printf("libusb_control_transfer returned %d\n", err_code);
 #endif
-      );
+
 }
 
 control_ret_t control_query_version(control_version_t *version)

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -32,6 +32,17 @@ static const int sync_timeout_ms = 100;
 /* Control query transfers require smaller buffers */
 #define VERSION_MAX_PAYLOAD_SIZE 64
 
+control_ret_t debug_libusb_error(int ret_code)
+{
+#if defined _WIN32
+    printf("libusb_control_transfer returned %s\n", usb_strerror());
+#elif defined __APPLE__
+    printf("libusb_control_transfer returned %s\n", libusb_error_name(ret));
+#elif defined __linux
+    printf("libusb_control_transfer returned %d\n", ret);
+#endif
+}
+
 control_ret_t control_query_version(control_version_t *version)
 {
   uint16_t windex, wvalue, wlength;
@@ -56,7 +67,7 @@ control_ret_t control_query_version(control_version_t *version)
   num_commands++;
 
   if (ret != sizeof(control_version_t)) {
-    printf("libusb_control_transfer returned %s\n", libusb_error_name(ret));
+    debug_libusb_error(ret);
     return CONTROL_ERROR;
   }
 
@@ -120,7 +131,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   num_commands++;
 
   if (ret != (int)payload_len) {
-    printf("libusb_control_transfer returned %s\n",  libusb_error_name(ret));
+    debug_libusb_error(ret);
     return CONTROL_ERROR;
   }
 
@@ -155,7 +166,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   num_commands++;
 
   if (ret != (int)payload_len) {
-    printf("libusb_control_transfer returned %s\n",  libusb_error_name(ret));
+    debug_libusb_error(ret);
     return CONTROL_ERROR;
   }
 

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -32,15 +32,17 @@ static const int sync_timeout_ms = 100;
 /* Control query transfers require smaller buffers */
 #define VERSION_MAX_PAYLOAD_SIZE 64
 
-control_ret_t debug_libusb_error(int ret_code)
+control_ret_t debug_libusb_error(int err_code)
 {
+      printf("libusb_control_transfer returned %s\n",
 #if defined _WIN32
-    printf("libusb_control_transfer returned %s\n", usb_strerror());
+                  usb_strerror()
 #elif defined __APPLE__
-    printf("libusb_control_transfer returned %s\n", libusb_error_name(ret));
+                  libusb_error_name(err_code)
 #elif defined __linux
-    printf("libusb_control_transfer returned %d\n", ret);
+                  err_code
 #endif
+      );
 }
 
 control_ret_t control_query_version(control_version_t *version)


### PR DESCRIPTION
debug_libusb_error now prints based on OS and uses
correct error translation function