### PR TITLE
Fix for control_read_command() for xScope on Windows

### DIFF
--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -102,7 +102,10 @@ control_ret_t control_init_xscope(const char *host_str, const char *port_str)
 
   // wait for xSCOPE probe registration
   while (probe_id == -1) {
+    // add a pause for Windows platforms only
+    #ifndef _WIN32
     pause_short();
+    #endif
   }
 
   return CONTROL_SUCCESS;
@@ -126,7 +129,7 @@ control_ret_t control_query_version(control_version_t *version)
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    // do nothing
+    pause_short();
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -129,7 +129,10 @@ control_ret_t control_query_version(control_version_t *version)
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
+    // add a pause for Windows platforms only
+    #ifndef _WIN32
     pause_short();
+    #endif
   }
 
   DBG(printf("response: "));


### PR DESCRIPTION
- added a pause