### PR TITLE
Fixed usage pause_short() on xScope host application 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Device control library change log
 =================================
 
+3.2.1
+-----
+  * Fixed XSCOPE hanging on Windows platforms
+
 3.2.0
 -----
 

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -127,7 +127,7 @@ control_ret_t control_query_version(control_version_t *version)
   
   // wait for response on xSCOPE probe
   while (record_count == 0) {
-    // do nothing
+    pause_short();
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -102,7 +102,7 @@ control_ret_t control_init_xscope(const char *host_str, const char *port_str)
 
   // wait for xSCOPE probe registration
   while (probe_id == -1) {
-    // do nothing, probe_id is a volatile variable
+    pause_short();
   }
 
   return CONTROL_SUCCESS;
@@ -186,7 +186,7 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
   }
   // wait for response on xSCOPE probe
   while (record_count == 0) { 
-    // do nothing, record_count is a volatile variable
+    pause_short();
   }
 
   DBG(printf("response: "));
@@ -217,7 +217,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
   
   // wait for response on xSCOPE probe
   while (record_count == 0) {
-    // do nothing, record_count is a volatile variable
+    pause_short();
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -20,8 +20,8 @@
 
 #define UNUSED_PARAMETER(x) (void)(x)
 
-static unsigned int probe_id = 0xffffffff;
-static size_t record_count = 0;
+static volatile unsigned int probe_id = 0xffffffff;
+static volatile size_t record_count = 0;
 static unsigned char *last_response = NULL;
 static struct control_xscope_response *last_response_struct = NULL;
 static unsigned last_response_length = 0;
@@ -102,7 +102,7 @@ control_ret_t control_init_xscope(const char *host_str, const char *port_str)
 
   // wait for xSCOPE probe registration
   while (probe_id == -1) {
-    pause_short();
+    // do nothing, probe_id is a volatile variable
   }
 
   return CONTROL_SUCCESS;
@@ -124,9 +124,10 @@ control_ret_t control_query_version(control_version_t *version)
     printf("xscope_ep_request_upload failed\n");
     return CONTROL_ERROR;
   }
-
-  while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+  
+  // wait for response on xSCOPE probe
+  while (record_count == 0) {
+    // do nothing
   }
 
   DBG(printf("response: "));
@@ -183,9 +184,9 @@ control_write_command(control_resid_t resid, control_cmd_t cmd,
     printf("xscope_ep_request_upload failed\n");
     return CONTROL_ERROR;
   }
-
-  while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+  // wait for response on xSCOPE probe
+  while (record_count == 0) { 
+    // do nothing, record_count is a volatile variable
   }
 
   DBG(printf("response: "));
@@ -213,9 +214,10 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
     printf("xscope_ep_request_upload failed\n");
     return CONTROL_ERROR;
   }
-
-  while (record_count == 0) { // wait for response on xSCOPE probe
-    pause_short();
+  
+  // wait for response on xSCOPE probe
+  while (record_count == 0) {
+    // do nothing, record_count is a volatile variable
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -102,10 +102,7 @@ control_ret_t control_init_xscope(const char *host_str, const char *port_str)
 
   // wait for xSCOPE probe registration
   while (probe_id == -1) {
-    // add a pause for Windows platforms only
-    #ifdef _WIN32
     pause_short();
-    #endif
   }
 
   return CONTROL_SUCCESS;
@@ -129,10 +126,7 @@ control_ret_t control_query_version(control_version_t *version)
   }
 
   while (record_count == 0) { // wait for response on xSCOPE probe
-    // add a pause for Windows platforms only
-    #ifdef _WIN32
     pause_short();
-    #endif
   }
 
   DBG(printf("response: "));

--- a/lib_device_control/module_build_info
+++ b/lib_device_control/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 3.2.0
+VERSION = 3.2.1
 
 DEPENDENT_MODULES = lib_xassert(>=3.0.0) lib_logging(>=2.1.0)
 


### PR DESCRIPTION
- set variables as volatile
- used pause_short() for all the platforms 
- updated CHANGELOG and module_build_info 