### PR TITLE
Fix for xScope on Windows machine

### DIFF
--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -232,7 +232,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
 
 control_ret_t control_cleanup_xscope(void)
 {
-  #ifdef WIN32
+  #ifdef _WIN32
   // Bug in 14.1 means this is required on Windows but not OSX
   xscope_ep_disconnect();
   #endif


### PR DESCRIPTION
now xscope_ep_disconnect() is called and the client socket is correctly closed. WIN32 without underscore is not defined in all Windows platforms.

I tested it only on my Win7 machine, it would be good to see if the regression tests are successful now.