### PR TITLE
Fix for xScope on Windows machine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,8 @@ Device control library change log
 
 3.2.1
 -----
-  * Fixed XSCOPE hanging on Windows platforms
+  * Fix XSCOPE hanging on Windows platforms
+  * Fix XSCOPE reconnection failure on Windows platforms 
 
 3.2.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,8 +3,11 @@ Device control library change log
 
 3.2.1
 -----
-  * Fix XSCOPE hanging on Windows platforms
-  * Fix XSCOPE reconnection failure on Windows platforms 
+
+  * Fix an issue on Windows where xSCOPE connection hangs on
+    Windows (#17871)
+  * Fix an issue on Windows where first xSCOPE connection succeeds,
+    but subsequent ones fail with "socket reply error" (#47)
 
 3.2.0
 -----

--- a/lib_device_control/host/device_access_xscope.c
+++ b/lib_device_control/host/device_access_xscope.c
@@ -232,7 +232,7 @@ control_read_command(control_resid_t resid, control_cmd_t cmd,
 
 control_ret_t control_cleanup_xscope(void)
 {
-  #ifdef WIN32
+  #ifdef _WIN32
   // Bug in 14.1 means this is required on Windows but not OSX
   xscope_ep_disconnect();
   #endif


### PR DESCRIPTION
Now xscope_ep_disconnect() is called and the client socket is correctly closed. WIN32 without underscore is not defined in all Windows platforms.

No change is required on the tools files.

I tested it only on my Win7 machine, it would be good to see if the regression tests are successful now.