### PR TITLE
Updates for USB host API

### DIFF
--- a/lib_device_control/host/control_host.h
+++ b/lib_device_control/host/control_host.h
@@ -55,6 +55,15 @@ control_ret_t control_init_i2c(unsigned char i2c_slave_address);
 control_ret_t control_cleanup_i2c(void);
 #endif
 #if USE_USB || __DOXYGEN__
+
+/** Print the list of the USB devices connected to the host machine
+ *
+ *  \param vendor_id   Vendor ID of USB devices to find
+ *
+ *  \returns           Whether any connected device is found
+ */
+control_ret_t list_connected_devices(int vendor_id);
+
 /** Initialize the USB host interface
  *
  *  \param vendor_id     Vendor ID of controlled USB device

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -33,6 +33,8 @@ static const int sync_timeout_ms = 100;
 void debug_libusb_error(int err_code)
 {
 #if defined _WIN32
+  /* err_code is not used in Windows platforms */
+  (void) err_code;
   printf("libusb_control_transfer returned %s\n", usb_strerror());
 #elif defined __APPLE__
   printf("libusb_control_transfer returned %s\n", libusb_error_name(err_code));


### PR DESCRIPTION
- add list_connected_devices()
- silence warning for Windows

All the changes are backward compatible and they have been tested on both Windows and MacOS.