### PR TITLE
Increase USB timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,40 +10,6 @@ pipeline {
     REPO = 'lib_device_control'
     VIEW = "${env.JOB_NAME.contains('PR-') ? REPO+'_'+env.CHANGE_TARGET : REPO+'_'+env.BRANCH_NAME}"
   }
-  triggers {
-    /* Trigger this Pipeline on changes to the repos dependencies
-     *
-     * If this Pipeline is running in a pull request, the triggers are set
-     * on the base branch the PR is set to merge in to.
-     *
-     * Otherwise the triggers are set on the branch of a matching name to the
-     * one this Pipeline is on.
-     */
-    upstream(
-      upstreamProjects:
-        (env.JOB_NAME.contains('PR-') ?
-          "../lib_gpio/${env.CHANGE_TARGET}," +
-          "../lib_i2c/${env.CHANGE_TARGET}," +
-          "../lib_logging/${env.CHANGE_TARGET}," +
-          "../lib_mic_array_board_support/${env.CHANGE_TARGET}," +
-          "../lib_usb/${env.CHANGE_TARGET}," +
-          "../lib_xassert/${env.CHANGE_TARGET}," +
-          "../tools_released/${env.CHANGE_TARGET}," +
-          "../tools_xmostest/${env.CHANGE_TARGET}," +
-          "../xdoc_released/${env.CHANGE_TARGET}"
-        :
-          "../lib_gpio/${env.BRANCH_NAME}," +
-          "../lib_i2c/${env.BRANCH_NAME}," +
-          "../lib_logging/${env.BRANCH_NAME}," +
-          "../lib_mic_array_board_support/${env.BRANCH_NAME}," +
-          "../lib_usb/${env.BRANCH_NAME}," +
-          "../lib_xassert/${env.BRANCH_NAME}," +
-          "../tools_released/${env.BRANCH_NAME}," +
-          "../tools_xmostest/${env.BRANCH_NAME}," +
-          "../xdoc_released/${env.BRANCH_NAME}"),
-      threshold: hudson.model.Result.SUCCESS
-    )
-  }
   options {
     skipDefaultCheckout()
   }

--- a/lib_device_control/host/device_access_usb.c
+++ b/lib_device_control/host/device_access_usb.c
@@ -25,7 +25,7 @@ static usb_dev_handle *devh = NULL;
 static libusb_device_handle *devh = NULL;
 #endif
 
-static const int sync_timeout_ms = 100;
+static const int sync_timeout_ms = 500;
 
 /* Control query transfers require smaller buffers */
 #define VERSION_MAX_PAYLOAD_SIZE 64


### PR DESCRIPTION
libusb uses a timeout value that in the USB HAL is currently set at 100ms. I don't think there is a specific reason behind that value, and a longer timeout such as 500ms (USB 2.0 specification 9.2.6.4) would work better.

I have been recently debugging a DFU scenario where a longer timeout would make it not an issue at all